### PR TITLE
Restructuring product description fields

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -470,7 +470,7 @@ module ApplicationHelper
 	# Tries to find a ContentTranslation for the provided field for current locale. Falls
 	# back to language only or default (english)
 	def translate_content(object, method)
-	  c = object[method] # (default)
+    c = object.send(method) # (default)
     return c if I18n.locale == I18n.default_locale || I18n.locale == 'en'
 	  parent_locale = (I18n.locale.to_s.match(/^(.*)-/)) ? $1 : false
 	  translations = ContentTranslation.where(content_type: object.class.to_s, content_id: object.id, content_method: method.to_s)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -45,6 +45,7 @@ class Product < ActiveRecord::Base
   has_many :product_videos, -> { order('position') }, dependent: :destroy
   has_many :product_solutions, dependent: :destroy
   has_many :solutions, through: :product_solutions
+  has_many :product_descriptions, dependent: :destroy
   belongs_to :product_status
   belongs_to :brand, touch: true
   has_many :parent_products # Where this is the child (ie, an e-pedal child of the iStomp)
@@ -120,6 +121,51 @@ class Product < ActiveRecord::Base
     rescue
       false
     end
+  end
+
+  # Replacing "description" column with external table
+  def description_field
+    product_descriptions.where(content_name: "description").first_or_initialize
+  end
+
+  def description
+    description_field.content
+  end
+
+  def description=(content)
+    d = description_field
+    d.content = content
+    d.save
+  end
+
+  # Replacing "features" column with external table
+  def features_field
+    product_descriptions.where(content_name: "features").first_or_initialize
+  end
+
+  def features
+    features_field.content
+  end
+
+  def features=(content)
+    f = features_field
+    f.content = content
+    f.save
+  end
+
+  # Replacing "extended_description" column with external table
+  def extended_description_field
+    product_descriptions.where(content_name: "extended_description").first_or_initialize
+  end
+
+  def extended_description
+    extended_description_field.content
+  end
+
+  def extended_description=(content)
+    e = extended_description_field
+    e.content = content
+    e.save
   end
 
   def current_sub_products

--- a/app/models/product_description.rb
+++ b/app/models/product_description.rb
@@ -1,0 +1,18 @@
+class ProductDescription < ActiveRecord::Base
+  belongs_to :product, touch: true
+
+  validates :product, presence: true
+  validates :content_name, presence: true
+
+  # Join two content fields together
+  def content
+    content_part1.to_s + " " + content_part2.to_s
+  end
+
+  # TODO: This is where I want to split the content into two
+  # fields if it is really long. For now, just hoping it  will fit
+  # in one columns.
+  def content=(new_content)
+    self.content_part1 = new_content
+  end
+end

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -62,12 +62,12 @@
 
 <% end %>
 
-  <%= f.input :description, input_html: { class: "mceEditor", style: "height: 400px;"} %><br/>
+  <%= f.input :description, as: :text, input_html: { class: "mceEditor", style: "height: 400px;"} %><br/>
   <% if @product.layout_class == 'epedal' %> <span class="small"> For epedals, only provide the first paragraph description here.</span><% end %>
   <br />
 
 
-  <%= f.input :extended_description, input_html: { class: "mceEditor", style: "height: 300px;"} %><br/>
+  <%= f.input :extended_description, as: :text, input_html: { class: "mceEditor", style: "height: 300px;"} %><br/>
   <% if @product.layout_class == 'epedal' %> <span class="small"> For epedals, only provide the description of the controls here.</span><% end %>
 
 <div class="row">
@@ -77,7 +77,7 @@
 </div>
 
 <% unless @product.layout_class == 'epedal' %>
-	<%= f.input :features, input_html: { class: "mceEditor", style: "height: 250px;"} %><br/>
+	<%= f.input :features, as: :text, input_html: { class: "mceEditor", style: "height: 250px;"} %><br/>
 <% end %>
 
 <div class="row">

--- a/db/migrate/20161219185116_create_product_descriptions.rb
+++ b/db/migrate/20161219185116_create_product_descriptions.rb
@@ -1,0 +1,45 @@
+class CreateProductDescriptions < ActiveRecord::Migration
+  def up
+    create_table :product_descriptions, force: true do |t|
+      t.integer :product_id
+      t.string :content_name
+      t.text :content_part1
+      t.text :content_part2
+
+      t.timestamps null: false
+    end
+    add_index :product_descriptions, :product_id
+    add_index :product_descriptions, :content_name
+
+    Product.all.each do |product|
+      d = ProductDescription.where(product_id: product.id, content_name: "description").first_or_initialize
+      d.content = Product.where(id: product.id).pluck(:description).first
+      d.save
+
+      e = ProductDescription.where(product_id: product.id, content_name: "extended_description").first_or_initialize
+      e.content = Product.where(id: product.id).pluck(:extended_description).first
+      e.save
+
+      f = ProductDescription.where(product_id: product.id, content_name: "features").first_or_initialize
+      f.content = Product.where(id: product.id).pluck(:features).first
+      f.save
+    end
+
+    remove_column :products, :description
+    remove_column :products, :extended_description
+    remove_column :products, :features
+  end
+
+  def down
+    add_column :products, :description, :text
+    add_column :products, :extended_description, :text
+    add_column :products, :features, :text
+
+    ProductDescription.all.each do |pd|
+      product = Product.find(pd.product_id)
+      product.update_column(pd.content_name, pd.content_part1)
+    end
+
+    drop_table :product_descriptions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207172537) do
+ActiveRecord::Schema.define(version: 20161219185116) do
 
   create_table "admin_logs", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
@@ -956,6 +956,18 @@ ActiveRecord::Schema.define(version: 20161207172537) do
   add_index "product_cabinets", ["cabinet_id"], name: "index_product_cabinets_on_cabinet_id", using: :btree
   add_index "product_cabinets", ["product_id"], name: "index_product_cabinets_on_product_id", using: :btree
 
+  create_table "product_descriptions", force: :cascade do |t|
+    t.integer  "product_id",    limit: 4
+    t.string   "content_name",  limit: 255
+    t.text     "content_part1", limit: 65535
+    t.text     "content_part2", limit: 65535
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+  end
+
+  add_index "product_descriptions", ["content_name"], name: "index_product_descriptions_on_content_name", using: :btree
+  add_index "product_descriptions", ["product_id"], name: "index_product_descriptions_on_product_id", using: :btree
+
   create_table "product_documents", force: :cascade do |t|
     t.integer  "product_id",            limit: 4
     t.string   "language",              limit: 255
@@ -1197,21 +1209,18 @@ ActiveRecord::Schema.define(version: 20161207172537) do
   create_table "products", force: :cascade do |t|
     t.string   "name",                           limit: 255
     t.string   "sap_sku",                        limit: 255
-    t.text     "description",                    limit: 65535
     t.text     "short_description",              limit: 65535
     t.text     "keywords",                       limit: 65535
     t.integer  "product_status_id",              limit: 4
     t.boolean  "rohs",                                         default: true
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "extended_description",           limit: 65535
     t.string   "cached_slug",                    limit: 255
     t.string   "background_image_file_name",     limit: 255
     t.integer  "background_image_file_size",     limit: 4
     t.string   "background_image_content_type",  limit: 255
     t.datetime "background_image_updated_at"
     t.string   "background_color",               limit: 255
-    t.text     "features",                       limit: 65535
     t.string   "password",                       limit: 255
     t.text     "previewers",                     limit: 65535
     t.boolean  "has_pedals",                                   default: false

--- a/spec/factories/product_descriptions.rb
+++ b/spec/factories/product_descriptions.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :product_description do
+    product
+    content_name "description"
+    content_part1 "MyText"
+    content_part2 "MyText"
+  end
+end

--- a/spec/models/product_description_spec.rb
+++ b/spec/models/product_description_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ProductDescription, type: :model do
+
+  before :all do
+    @product_description = FactoryGirl.create(:product_description)
+  end
+
+  subject { @product_description }
+  it { should respond_to :product }
+end
+


### PR DESCRIPTION
Soundcraft descriptions are exceedingly long. So, this moves the description fields to a separate table.