### PR TITLE
Updating redirects to be more specific

### DIFF
--- a/config/nginx/amx.conf
+++ b/config/nginx/amx.conf
@@ -31,19 +31,19 @@ server {
   # ---- REDIRECTS FOR OLD LINKS ----
 
   # Former Spotlight sites
-  location ~* /amxroombook/? { return 301 $scheme://$http_host/en-US/product_families/scheduling-panels; }
-  location ~* /enova/? { return 301 $scheme://$http_host/en-US/product_families/digital-media-switchers; }
-  location ~* /enzo/? { return 301 $scheme://$http_host/en-US/products/nmx-mm-1000; }
-  location ~* /hydraport/? { return 301 $scheme://$http_host/en-US/product_families/architectural-connectivity; }
-  location ~* /modero/? { return 301 $scheme://$http_host/en-US/product_families/touch-panels; }
-  location ~* /rms/? { return 301 $scheme://$http_host/en-US/product_families/resource-management; }
-  location ~* /rpm/? { return 301 $scheme://$http_host/en-US/products/nss-rpm; }
-  location ~* /security/? { return 301 $scheme://$http_host/network-security; }
-  location ~* /sereno/? { return 301 $scheme://$http_host/products/nmx-vcc-1000; }
-  location ~* /svsi/? { return 301 $scheme://$http_host/en-US/product_families/networked-av; }
+  location ~* ^/amxroombook/? { return 301 $scheme://$http_host/en-US/product_families/scheduling-panels; }
+  location ~* ^/enova/? { return 301 $scheme://$http_host/en-US/product_families/digital-media-switchers; }
+  location ~* ^/enzo/? { return 301 $scheme://$http_host/en-US/products/nmx-mm-1000; }
+  location ~* ^/hydraport/? { return 301 $scheme://$http_host/en-US/product_families/architectural-connectivity; }
+  location ~* ^/modero/? { return 301 $scheme://$http_host/en-US/product_families/touch-panels; }
+  location ~* ^/rms/? { return 301 $scheme://$http_host/en-US/product_families/resource-management; }
+  location ~* ^/rpm/? { return 301 $scheme://$http_host/en-US/products/nss-rpm; }
+  location ~* ^/security/? { return 301 $scheme://$http_host/network-security; }
+  location ~* ^/sereno/? { return 301 $scheme://$http_host/products/nmx-vcc-1000; }
+  location ~* ^/svsi/? { return 301 $scheme://$http_host/en-US/product_families/networked-av; }
 
   # Former Business (Automate) site
-  location ~* /automate/? { return 301 $scheme://$http_host/en-US/market_segments/corporate; }
+  location ~* ^/automate/? { return 301 $scheme://$http_host/en-US/market_segments/corporate; }
   location = /automate/aboutamx.aspx { return 301 $scheme://$http_host/en-US/about-amx; }
   location = /automate/associations.aspx { return 301 $scheme://$http_host/en-US/amx-associations; }
   location = /automate/av-over-ip.aspx { return 301 $scheme://$http_host/en-US/premium-content_technology-managers-guide-to-av-over-ip; }
@@ -72,7 +72,7 @@ server {
   location = /automate/workbook-video-streaming.aspx { return 301 $scheme://$http_host/en-US/premium-content_workbook-to-planning-for-video-streaming; }
 
   # Former Education site
-  location ~* /education/? { return 301 $scheme://$http_host/en-US/market_segments/education; }
+  location ~* ^/education/? { return 301 $scheme://$http_host/en-US/market_segments/education; }
   location ~* /education/buy/? { return 301 $scheme://$http_host/en-US/contacts; }
   location ~* /education/buy/warranty/? { return 301 $scheme://$http_host/en-US/amx-warranty; }
   location ~* /education/innovationawards/? { return 301 $scheme://$http_host/education/; }
@@ -86,7 +86,7 @@ server {
   location ~* /education/support/warranty/? { return 301 $scheme://$http_host/en-US/amx-warranty; }
 
   # Former Government site
-  location ~* /government/? { return 301 $scheme://$http_host/en-US/market_segments/government; }
+  location ~* ^/government/? { return 301 $scheme://$http_host/en-US/market_segments/government; }
   location ~* /government/buy/? { return 301 $scheme://$http_host/en-US/amx-support; }
   location ~* /government/buy/expedited/? { return 301 $scheme://$http_host/en-US/government-expedited-order-process; }
   location ~* /government/buy/ogs/? { return 301 $scheme://$http_host/en-US/ny-ogs; }
@@ -171,18 +171,18 @@ server {
   location ~* /automate/plan/resources/? { return 301 $scheme://$http_host/en-US/learn; }
 
   # Trade site top nav links
-  location ~* /aboutamx/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /newsroom/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /products/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /markets/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /partners/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /techcenter/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /training/? { return 301 http://trade.amx.com$request_uri; }
-  location ~* /contactamx/? { return 301 $scheme://$http_host/en-US/contacts; }
+  location ~* ^/aboutamx/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/newsroom/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/products/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/markets/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/partners/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/techcenter/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/training/? { return 301 http://trade.amx.com$request_uri; }
+  location ~* ^/contactamx/? { return 301 $scheme://$http_host/en-US/contacts; }
 
   # Trade site misc
-  location ~* /rpmmodulerequest/? { return 301 http://trade.amx.com$request_uri; }
-  
+  location ~* ^/rpmmodulerequest/? { return 301 http://trade.amx.com$request_uri; }
+
   # EAP
   location ~* /education/eap/? { return 301 http://eap.amx.com; }
 
@@ -191,8 +191,8 @@ server {
   location ~* /education/plan/resources/? { return 301 $scheme://$http_host/en-US/learn; }
 
   # Former Government site
-  location ~* /government/learn/? { return 301 $scheme://$http_host/en-US/learn; }
-  location ~* /government/plan/resources/? { return 301 $scheme://$http_host/en-US/learn; }
+  location ~* ^/government/learn/? { return 301 $scheme://$http_host/en-US/learn; }
+  location ~* ^/government/plan/resources/? { return 301 $scheme://$http_host/en-US/learn; }
 
   ### END PATH MATCHES  ###
 


### PR DESCRIPTION
Putting the carat in front of the expressions to match at the beginning of the URLs only. Otherwise things like /products/ hijacks all the new product pages.