### PR TITLE
Adding per-product registration notices

### DIFF
--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -174,11 +174,17 @@
 
 	<div class="row">
 		<div class="large-12 columns">
-		<div class="panel">
-			<h5>Alert</h5>
-			<%= f.input :alert, label: "Optional alert to show on the top of the product page." %>
-			<%= f.input :show_alert, label: "Enable the alert message." %>
-		</div>
+      <div class="panel">
+        <h5>Alert</h5>
+        <%= f.input :alert, label: "Optional alert to show on the top of the product page." %>
+        <%= f.input :show_alert, label: "Enable the alert message." %>
+      </div>
+      <div class="panel">
+        <h5>Registration Notice</h5>
+        <p>When a customer registers this product, they'll receive a standard confirmation email with basic
+        information. If owners of this product should receive additional information in that email, provide
+        the content below. Basic HTML formatting is permitted.</p>
+        <%= f.input :registration_notice, label: false %>
 		</div>
 	</div>
 

--- a/app/views/site_mailer/confirm_product_registration.html.erb
+++ b/app/views/site_mailer/confirm_product_registration.html.erb
@@ -27,6 +27,11 @@
 <p><%= @warranty_registration.comments %></p>
 <% end %>
 
+<% if @warranty_registration.product.registration_notice.present? %>
+<h4>Additional Information for <%= @warranty_registration.product.name %> Owners</h4>
+<%=raw @warranty_registration.product.registration_notice %>
+<% end %>
+
 <p>-----------------------------</p>
 <p>Enjoy your new <%= @warranty_registration.product.name %>.
 	Let us know if we can help at our support address:

--- a/db/migrate/20170314154953_add_registration_notice_to_products.rb
+++ b/db/migrate/20170314154953_add_registration_notice_to_products.rb
@@ -1,0 +1,5 @@
+class AddRegistrationNoticeToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :registration_notice, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170307162258) do
+ActiveRecord::Schema.define(version: 20170314154953) do
 
   create_table "admin_logs", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
@@ -1276,6 +1276,7 @@ ActiveRecord::Schema.define(version: 20170307162258) do
     t.boolean  "show_recommended_verticals",                   default: true
     t.boolean  "enterprise",                                   default: false
     t.boolean  "entertainment",                                default: false
+    t.text     "registration_notice",            limit: 65535
   end
 
   add_index "products", ["brand_id", "product_status_id"], name: "index_products_on_brand_id_and_product_status_id", using: :btree


### PR DESCRIPTION
This satisfies the request for Studer Micro series owners to get an extra link to download software when they register the product. The content of that notice is available to edit on the product form of the admin.