### PR TITLE
Using maxmind IP database (v2) for IP lookups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'execjs'
 gem 'therubyrhino'
 gem 'whenever' #, require: false
 gem "simple_form", ">= 5.0.0"
+gem 'countries'
 gem 'country_select'
 gem 'chosen-rails', git: 'https://github.com/adamtao/chosen-rails'
 gem 'language_list'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -743,6 +743,7 @@ DEPENDENCIES
   chosen-rails!
   coffee-rails
   colorize
+  countries
   country_select
   daemons
   dalli

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -203,7 +203,9 @@ private
         session['geo_usa'] = (clean_country_code == "us") ? true : false
       else
         unless session['geo_country']
-          lookup = Geokit::Geocoders::IpApiGeocoder.do_geocode(request.remote_ip)
+          # MultiGeocoder should automatically use IP services in the order of
+          # preference indicated in config/initializers/geokit_config.rb
+          lookup = Geokit::Geocoders::MultiGeocoder.do_geocode(request.remote_ip)
           if lookup.present? && lookup.country_code.present?
             session['geo_country'] = lookup.country_code
             session['geo_usa'] = lookup.is_us?

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,5 +1,6 @@
 # Include a little hack to get things working with Rails3
 #  require Rails.root.join('lib', 'merge_conditions.rb')
+require Rails.root.join('lib', 'geolite2city.rb')
 
 # For geocoder_plus
 # require 'api_cache'
@@ -90,6 +91,7 @@ Geokit::Geocoders::provider_order = [:bing, :google] #:geonames] #, :yahoo, :goo
 # The IP provider order. Valid symbols are :ip,:geo_plugin.
 # As before, make sure you read up on relevant Terms of Use for each.
 # Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
+Geokit::Geocoders::ip_provider_order = [:geolite2_city, :ip_api]
 
 # Disable HTTPS globally.  This option can also be set on individual
 # geocoder classes.

--- a/lib/geolite2city.rb
+++ b/lib/geolite2city.rb
@@ -1,0 +1,44 @@
+require 'geokit'
+require 'maxmind/geoip2'
+
+module Geokit
+  module Geocoders
+
+    # Default path on the system for the Maxmind database is:
+    #
+    #  /usr/share/GeoIP/GeoLite2-City.mmdb
+    #
+    # Set an environment variable 'maxmind_database_path' to
+    # override the path.
+    #
+    @@geoip2_data_path = (ENV.keys.include?('maxmind_database_path')) ? ENV['maxmind_database_path'] : '/usr/share/GeoIP/GeoLite2-City.mmdb'
+    __define_accessors
+
+    class Geolite2CityGeocoder < Geocoder
+      def self.do_geocode(ip, optinos={})
+        return GeoLoc.new unless /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})?$/.match(ip)
+
+        reader = ::MaxMind::GeoIP2::Reader.new( database: Geocoders::geoip2_data_path )
+
+        begin
+          res = reader.city(ip)
+
+          loc = GeoLoc.new({
+            provider: 'maxmind2_city',
+            lat: res.location.latitude,
+            lng: res.location.longitude,
+            city: res.city.name,
+            state: res.subdivisions.first.name,
+            zip: res.postal.code,
+            country_code: res.country.iso_code
+          })
+          loc.success = res.city.name && res.city.name != ''
+          loc
+        rescue ::MaxMind::GeoIP2::AddressNotFoundError
+          return GeoLoc.new
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Utilize the locally installed maxmind databases we've paid for to avoid calls to ip-api where possible. If the IP is missing from maxmind, it should revert to ip-api.